### PR TITLE
Access monaco editor by URI

### DIFF
--- a/packages/playground/src/app/Editor/index.tsx
+++ b/packages/playground/src/app/Editor/index.tsx
@@ -15,7 +15,7 @@ export const Editor = (): ReactElement => {
   const editorDidMount = (editor: MonacoEditor['editor']): void => {
     if (editor) {
       editor.focus();
-      let uri = editor.getModel()?.uri;
+      const uri = editor.getModel()?.uri;
       if (uri) dispatch({ type: 'SET_URI', payload: uri });
     }
   };

--- a/packages/playground/src/app/Editor/index.tsx
+++ b/packages/playground/src/app/Editor/index.tsx
@@ -15,6 +15,8 @@ export const Editor = (): ReactElement => {
   const editorDidMount = (editor: MonacoEditor['editor']): void => {
     if (editor) {
       editor.focus();
+      let uri = editor.getModel()?.uri;
+      if (uri) console.log('uri: ', uri);
     }
   };
 

--- a/packages/playground/src/app/Editor/index.tsx
+++ b/packages/playground/src/app/Editor/index.tsx
@@ -6,7 +6,7 @@ import { Dispatch, State } from '~/context/reducer';
 
 export const Editor = (): ReactElement => {
   const [code, setCode] = useState(exampleCode);
-  const [state]: [State, Dispatch] = useContext(AppContext);
+  const [state, dispatch]: [State, Dispatch] = useContext(AppContext);
 
   const handleChange = (newValue: string): void => {
     setCode(newValue);
@@ -16,7 +16,7 @@ export const Editor = (): ReactElement => {
     if (editor) {
       editor.focus();
       let uri = editor.getModel()?.uri;
-      if (uri) console.log('uri: ', uri);
+      if (uri) dispatch({ type: 'SET_URI', payload: uri });
     }
   };
 

--- a/packages/playground/src/context/reducer.ts
+++ b/packages/playground/src/context/reducer.ts
@@ -26,7 +26,8 @@ export type Action =
   | { type: 'SET_DARKMODE'; payload: boolean }
   | { type: 'SET_NUMBERING'; payload: boolean }
   | { type: 'SET_MINIMAP'; payload: boolean }
-  | { type: 'SET_COMPILE_STATE'; payload: CompileState };
+  | { type: 'SET_COMPILE_STATE'; payload: CompileState }
+  | { type: 'SET_URI'; payload: Uri };
 
 export type Dispatch = (action: Action) => void;
 
@@ -51,6 +52,11 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         compile: action.payload,
+      };
+    case 'SET_URI':
+      return {
+        ...state,
+        monacoUri: action.payload,
       };
     default:
       return state;

--- a/packages/playground/src/context/reducer.ts
+++ b/packages/playground/src/context/reducer.ts
@@ -1,10 +1,12 @@
 import { CompileApiResponse } from '~/api/compile';
+import { Uri } from 'monaco-editor/esm/vs/editor/editor.api';
 
 export const defaultState: State = {
   darkmode: true,
   minimap: true,
   numbering: true,
   compile: { type: 'NOT_ASKED' },
+  monacoUri: null,
 };
 
 export type State = {
@@ -12,6 +14,7 @@ export type State = {
   minimap: boolean;
   numbering: boolean;
   compile: CompileState;
+  monacoUri: Uri | null;
 };
 
 export type CompileState =

--- a/packages/playground/src/context/side-effects.ts
+++ b/packages/playground/src/context/side-effects.ts
@@ -1,6 +1,5 @@
 import { compileRequest } from '~/api/compile';
 import { State, Dispatch } from './reducer';
-import exampleCode from '../app/Editor/example-code';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 export async function compile(dispatch: Dispatch, state: State) {

--- a/packages/playground/src/context/side-effects.ts
+++ b/packages/playground/src/context/side-effects.ts
@@ -10,12 +10,16 @@ export async function compile(dispatch: Dispatch, state: State) {
   let { monacoUri: uri } = state;
 
   if (!uri) {
+    // ToDo: implement proper error handling
+    dispatch({ type: 'SET_COMPILE_STATE', payload: { type: 'NOT_ASKED' } });
     return;
   }
 
   let model = monaco.editor.getModel(uri);
 
   if (!model) {
+    // ToDo: implement proper error handling
+    dispatch({ type: 'SET_COMPILE_STATE', payload: { type: 'NOT_ASKED' } });
     return;
   }
 

--- a/packages/playground/src/context/side-effects.ts
+++ b/packages/playground/src/context/side-effects.ts
@@ -8,7 +8,21 @@ export async function compile(dispatch: Dispatch, state: State) {
 
   dispatch({ type: 'SET_COMPILE_STATE', payload: { type: 'IN_PROGRESS' } });
 
-  const result = await compileRequest({ source: exampleCode });
+  let { monacoUri: uri } = state;
+
+  if (!uri) {
+    return;
+  }
+
+  let model = monaco.editor.getModel(uri);
+
+  if (!model) {
+    return;
+  }
+
+  let code = model.getValue();
+
+  const result = await compileRequest({ source: code });
 
   dispatch({
     type: 'SET_COMPILE_STATE',

--- a/packages/playground/src/context/side-effects.ts
+++ b/packages/playground/src/context/side-effects.ts
@@ -7,7 +7,7 @@ export async function compile(dispatch: Dispatch, state: State) {
 
   dispatch({ type: 'SET_COMPILE_STATE', payload: { type: 'IN_PROGRESS' } });
 
-  let { monacoUri: uri } = state;
+  const { monacoUri: uri } = state;
 
   if (!uri) {
     // ToDo: implement proper error handling
@@ -15,7 +15,7 @@ export async function compile(dispatch: Dispatch, state: State) {
     return;
   }
 
-  let model = monaco.editor.getModel(uri);
+  const model = monaco.editor.getModel(uri);
 
   if (!model) {
     // ToDo: implement proper error handling
@@ -23,7 +23,7 @@ export async function compile(dispatch: Dispatch, state: State) {
     return;
   }
 
-  let code = model.getValue();
+  const code = model.getValue();
 
   const result = await compileRequest({ source: code });
 

--- a/packages/playground/src/context/side-effects.ts
+++ b/packages/playground/src/context/side-effects.ts
@@ -1,6 +1,7 @@
 import { compileRequest } from '~/api/compile';
 import { State, Dispatch } from './reducer';
 import exampleCode from '../app/Editor/example-code';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 export async function compile(dispatch: Dispatch, state: State) {
   if (state.compile.type === 'IN_PROGRESS') return;


### PR DESCRIPTION
We need global access to the monaco editor instance from all over the app: for compiling the source code, we need to obtain it first, later on, we need to replace the monaco editor workers with the Rust Analyzer web workers.

Them Monaco editor can be accessed via its [URI](https://microsoft.github.io/monaco-editor/api/classes/monaco.uri.html), by calling `monaco.editor.getModel(uri);` function from its API.

This PR:

- creates a URI field in the context state
- dispatches the editors URI to the context when monaco editor mounts
- retrieves the content of the monaco editor (the edited source code) for compile requests.