### PR TITLE
Fix sandbox compilation test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,4 @@ jobs:
       - name: Tag docker image
         run: docker tag docker.io/achimcc/ink-backend:latest ink-backend
       - name: Run tests
-        run: cargo test --workspace --exclude rust_analyzer_wasm --verbose --features docker_tests
+        run: cargo test --workspace --exclude rust_analyzer_wasm --verbose

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -18,6 +18,3 @@ sandbox = { path = "../sandbox" }
 
 [dev-dependencies]
 actix-rt = "2.3.0"
-
-[features]
-docker_tests = []

--- a/crates/sandbox/src/build_command.rs
+++ b/crates/sandbox/src/build_command.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tokio::process::Command;
 
-const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(1000);
+const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(10);
 
 const DOCKER_CONTAINER_NAME: &str = "ink-backend";
 

--- a/crates/sandbox/src/build_command.rs
+++ b/crates/sandbox/src/build_command.rs
@@ -102,7 +102,10 @@ fn build_basic_secure_docker_command() -> Command {
 fn build_execution_command() -> Vec<String> {
     let target_dir = "/target/ink";
 
-    let clean_cmd = format!("rm -rf {}/*", target_dir);
+    let clean_cmd = format!(
+        "rm -rf {}/contract.* {}/metadata.json",
+        target_dir, target_dir
+    );
     let build_cmd = "cargo contract build --offline".to_string();
     let move_cmd = format!("mv {}/contract.contract {}", target_dir, DOCKER_OUTPUT);
 

--- a/crates/sandbox/src/build_command.rs
+++ b/crates/sandbox/src/build_command.rs
@@ -70,7 +70,7 @@ fn build_docker_command(input_file: &Path, output_dir: &Path) -> Command {
 fn build_basic_secure_docker_command() -> Command {
     let mut cmd = docker_command!(
         "run",
-        //"--detach",
+        "--detach",
         "--cap-drop=ALL",
         // Needed to allow overwriting the file
         "--cap-add=DAC_OVERRIDE",

--- a/crates/sandbox/src/build_command.rs
+++ b/crates/sandbox/src/build_command.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tokio::process::Command;
 
-const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(10);
+const DOCKER_PROCESS_TIMEOUT_SOFT: Duration = Duration::from_secs(1000);
 
 const DOCKER_CONTAINER_NAME: &str = "ink-backend";
 
@@ -70,7 +70,7 @@ fn build_docker_command(input_file: &Path, output_dir: &Path) -> Command {
 fn build_basic_secure_docker_command() -> Command {
     let mut cmd = docker_command!(
         "run",
-        "--detach",
+        //"--detach",
         "--cap-drop=ALL",
         // Needed to allow overwriting the file
         "--cap-add=DAC_OVERRIDE",
@@ -100,10 +100,13 @@ fn build_basic_secure_docker_command() -> Command {
 }
 
 fn build_execution_command() -> Vec<String> {
-    let command = format!(
-        "cargo contract build --offline && mv /target/ink/contract.contract {}",
-        DOCKER_OUTPUT
-    );
+    let target_dir = "/target/ink";
+
+    let clean_cmd = format!("rm -rf {}/*", target_dir);
+    let build_cmd = "cargo contract build --offline".to_string();
+    let move_cmd = format!("mv {}/contract.contract {}", target_dir, DOCKER_OUTPUT);
+
+    let command = format!("{} && {} && {}", clean_cmd, build_cmd, move_cmd);
 
     let cmd = vec!["/bin/bash".to_string(), "-c".to_string(), command];
 

--- a/crates/sandbox/src/example_code.rs
+++ b/crates/sandbox/src/example_code.rs
@@ -14,7 +14,6 @@
 
 #[cfg(test)]
 pub mod tests {
-    #[cfg(feature = "docker_tests")]
     pub const FLIPPER_CODE: &str = r#"
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -138,7 +138,7 @@ pub enum CompilationResult {
 // CONSTANTS
 // -------------------------------------------------------------------------------------------------
 
-const DOCKER_PROCESS_TIMEOUT_HARD: Duration = Duration::from_secs(1200);
+const DOCKER_PROCESS_TIMEOUT_HARD: Duration = Duration::from_secs(12);
 
 // -------------------------------------------------------------------------------------------------
 // TRAIT IMPLEMENTATION

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -138,7 +138,7 @@ pub enum CompilationResult {
 // CONSTANTS
 // -------------------------------------------------------------------------------------------------
 
-const DOCKER_PROCESS_TIMEOUT_HARD: Duration = Duration::from_secs(12);
+const DOCKER_PROCESS_TIMEOUT_HARD: Duration = Duration::from_secs(1200);
 
 // -------------------------------------------------------------------------------------------------
 // TRAIT IMPLEMENTATION
@@ -178,6 +178,8 @@ impl Sandbox {
 
         let stdout = vec_to_str(output.stdout)?;
         let mut stderr = vec_to_str(output.stderr)?;
+
+        println!("here");
 
         let compile_response = match file {
             Some(file) => {
@@ -321,18 +323,19 @@ fn vec_to_str(v: Vec<u8>) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::example_code::tests::FLIPPER_CODE;
 
-    #[cfg(feature = "docker_tests")]
     fn compile_check(source: String) -> Option<bool> {
         Sandbox::new()
             .and_then(|sandbox| sandbox.compile(&CompilationRequest { source }))
             .map(|result| {
                 match result {
                     CompilationResult::Success {
-                        wasm: _,
+                        wasm,
                         stdout: _,
                         stderr: _,
-                    } => true,
+                    } => wasm.len() != 0,
                     CompilationResult::Error {
                         stdout: _,
                         stderr: _,
@@ -342,7 +345,6 @@ mod tests {
             .ok()
     }
 
-    #[cfg(feature = "docker_tests")]
     #[test]
     fn test_compile_valid_code() {
         let actual_result = compile_check(FLIPPER_CODE.to_string());
@@ -350,7 +352,6 @@ mod tests {
         assert_eq!(actual_result, Some(true))
     }
 
-    #[cfg(feature = "docker_tests")]
     #[test]
     fn test_compile_invalid_code() {
         let actual_result = compile_check("".to_string());

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -335,7 +335,7 @@ mod tests {
                         wasm,
                         stdout: _,
                         stderr: _,
-                    } => wasm.len() != 0,
+                    } => !wasm.is_empty(),
                     CompilationResult::Error {
                         stdout: _,
                         stderr: _,

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -179,8 +179,6 @@ impl Sandbox {
         let stdout = vec_to_str(output.stdout)?;
         let mut stderr = vec_to_str(output.stderr)?;
 
-        println!("here");
-
         let compile_response = match file {
             Some(file) => {
                 match read(&file) {


### PR DESCRIPTION
It turned out that the sandbox compilation tests did not run in CI. the reason for this was that they were behind a cargo feature flag, which was however declared in the wrong `Cargo.toml`. i decided it's better to omit the feature flag.

The PR

- removes the feature flag

and tries to make the actual test more waterproof by:

- [cleaning](https://github.com/paritytech/ink-playground/pull/109/files#diff-70f3cdfd262ed8e41549c5d0a795d32039a9ad50963a2e9ed0eaa74c2857cda5L103) the already compiled artefacts inside the `ink-backend` docker image. 
  _Ideally the artefacts should not be present in the docker image. The complexity here is that we run the docker container in `--detach` mode (like in rust-playground). If the waiting mechanism fails for some reason we'd serve the old `contract.constract` file. For now, I could manually affirm myself that this is not the case but this is of course not quite safe._
- [Check](https://github.com/paritytech/ink-playground/pull/109/files#diff-2eb0209ca3f158e406a1f99ff3ea55cb1178afbda047b93f2d7a9a65f03a07f1R336) if the compiled wasm is not empty. We could even think of enhancing this. (Wasm is actually a JSON and has the hashed source inside, etc...)