### PR TITLE
Fix yarn start (playground)

### DIFF
--- a/packages/playground/webpack.config.js
+++ b/packages/playground/webpack.config.js
@@ -83,7 +83,9 @@ module.exports = {
       // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
       languages: ['rust'],
     }),
-    new EnvironmentPlugin(['COMPILE_URL']),
+    new EnvironmentPlugin({
+      COMPILE_URL: '',
+    }),
   ],
   experiments: {
     asyncWebAssembly: true,


### PR DESCRIPTION
closes #65 

Adds default environment variable on the plugin level, as explained here: https://webpack.js.org/plugins/environment-plugin/#usage-with-default-values