### PR TITLE
ButtonWithIcon disabled and loading props

### DIFF
--- a/packages/components/__tests__/ButtonWithIcon.test.tsx
+++ b/packages/components/__tests__/ButtonWithIcon.test.tsx
@@ -30,11 +30,153 @@ describe('Given the ButtonWithIcon component is rendered', () => {
   });
 
   test('When Button is clicked', async () => {
-    // Given, When
+    // Given
     const testButton = await screen.findByText('testButton');
+    // When
+    testButton.click();
+    // Then ...
+    expect(wasClicked).toBeCalledTimes(1);
+  });
+});
+
+describe('Given Button states were changed', () => {
+  test('Given Button is rendered in disabled state', async () => {
+    // Given, When
+    const wasClicked: () => void = jest.fn();
+    render(
+      <ButtonWithIcon
+        label="testButtonDisabled"
+        Icon={DemoSvg}
+        testId={'buttonIcon'}
+        disabled={true}
+        onClick={() => {
+          wasClicked();
+        }}
+      />
+    );
+    const testButton = await screen.findByText('testButtonDisabled');
+    const disabledIcon = await screen.findByTestId('icon-disabled');
+
+    // Then ...
+    expect(testButton).toBeInTheDocument();
+    expect(testButton).toHaveClass('cursor-not-allowed');
+    expect(disabledIcon).toBeInTheDocument();
+  });
+
+  test('Given disabled Button is clicked', async () => {
+    // Given
+    const wasClicked: () => void = jest.fn();
+    render(
+      <ButtonWithIcon
+        label="testButtonDisabled"
+        Icon={DemoSvg}
+        testId={'buttonIcon'}
+        disabled={true}
+        onClick={() => {
+          wasClicked();
+        }}
+      />
+    );
+    const testButton = await screen.findByText('testButtonDisabled');
+
+    // When
     testButton.click();
 
     // Then ...
-    expect(wasClicked).toBeCalledTimes(1);
+    expect(wasClicked).toBeCalledTimes(0);
+  });
+
+  test('Given Button is rendered in loading state', async () => {
+    // Given, When
+    const wasClicked: () => void = jest.fn();
+    render(
+      <ButtonWithIcon
+        label="testButtonLoading"
+        Icon={DemoSvg}
+        testId={'buttonIcon'}
+        loading={true}
+        onClick={() => {
+          wasClicked();
+        }}
+      />
+    );
+    const testButton = await screen.findByText('testButtonLoading');
+    const loadingIcon = await screen.findByTestId('icon-loading');
+
+    // Then ...
+    expect(testButton).toBeInTheDocument();
+    expect(testButton).toHaveClass('cursor-not-allowed');
+    expect(loadingIcon).toBeInTheDocument();
+  });
+
+  test('Given loading Button is clicked', async () => {
+    // Given
+    const wasClicked: () => void = jest.fn();
+    render(
+      <ButtonWithIcon
+        label="testButtonLoading"
+        Icon={DemoSvg}
+        testId={'buttonIcon'}
+        loading={true}
+        onClick={() => {
+          wasClicked();
+        }}
+      />
+    );
+    const testButton = await screen.findByText('testButtonLoading');
+
+    // When
+    testButton.click();
+
+    // Then ...
+    expect(wasClicked).toBeCalledTimes(0);
+  });
+
+  test('Given Button is rendered in loading AND disabled state', async () => {
+    // Given, When
+    const wasClicked: () => void = jest.fn();
+    render(
+      <ButtonWithIcon
+        label="testButtonLoadingDisabled"
+        Icon={DemoSvg}
+        testId={'buttonIcon'}
+        loading={true}
+        disabled={true}
+        onClick={() => {
+          wasClicked();
+        }}
+      />
+    );
+    const testButton = await screen.findByText('testButtonLoadingDisabled');
+    const loadingIcon = await screen.findByTestId('icon-loading');
+
+    // Then ...
+    expect(testButton).toBeInTheDocument();
+    expect(testButton).toHaveClass('cursor-not-allowed');
+    expect(loadingIcon).toBeInTheDocument();
+  });
+
+  test('Given loading AND disabled Button is clicked', async () => {
+    // Given
+    const wasClicked: () => void = jest.fn();
+    render(
+      <ButtonWithIcon
+        label="testButtonLoadingDisabled"
+        Icon={DemoSvg}
+        testId={'buttonIcon'}
+        loading={true}
+        disabled={true}
+        onClick={() => {
+          wasClicked();
+        }}
+      />
+    );
+    const testButton = await screen.findByText('testButtonLoadingDisabled');
+
+    // When
+    testButton.click();
+
+    // Then ...
+    expect(wasClicked).toBeCalledTimes(0);
   });
 });

--- a/packages/components/src/ButtonWithIcon.tsx
+++ b/packages/components/src/ButtonWithIcon.tsx
@@ -20,7 +20,9 @@ export const ButtonWithIcon = ({
   loading,
 }: ButtonProps): ReactElement => {
   const disabledClasses =
-    disabled || loading ? 'cursor-not-allowed text-gray-600 bg-elevation' : '';
+    disabled || loading
+      ? 'cursor-not-allowed dark:text-gray-600 text-gray-400 dark:bg-elevation bg-gray-200'
+      : '';
 
   const IconOfState = (): ReactElement => {
     if (loading)

--- a/packages/components/src/ButtonWithIcon.tsx
+++ b/packages/components/src/ButtonWithIcon.tsx
@@ -27,12 +27,13 @@ export const ButtonWithIcon = ({
   const IconOfState = (): ReactElement => {
     if (loading)
       return (
-        <i className="pi pi-spinner animate-spin mt-1.5 mr-1.5" data-testid={'icon-loading'} />
+        <i className="pi pi-spinner animate-spin mt-1.5 mr-1.5 w-4" data-testid={'icon-loading'} />
       );
 
-    if (disabled) return <i className="pi pi-ban mt-1.5 mr-1.5" data-testid={'icon-disabled'} />;
+    if (disabled)
+      return <i className="pi pi-ban mt-1.5 mr-1.5 w-4" data-testid={'icon-disabled'} />;
 
-    return <Icon className={'mt-1.5 mr-1.5'} data-testid={testId} />;
+    return <Icon className={'mt-1.5 mr-1.5 w-4'} data-testid={testId} />;
   };
 
   return (

--- a/packages/components/src/ButtonWithIcon.tsx
+++ b/packages/components/src/ButtonWithIcon.tsx
@@ -7,15 +7,47 @@ export type ButtonProps = {
     e?: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>
   ) => void | Promise<void> | null;
   testId?: string;
+  disabled?: boolean;
+  loading?: boolean;
 };
 
-export const ButtonWithIcon = ({ label, Icon, onClick, testId }: ButtonProps): ReactElement => {
+export const ButtonWithIcon = ({
+  label,
+  Icon,
+  onClick,
+  testId,
+  disabled,
+  loading,
+}: ButtonProps): ReactElement => {
+  const isLoading = loading !== undefined ? loading : false;
+  const isDisabled = isLoading ? true : disabled !== undefined ? disabled : false;
+
+  const disabledClasses = isDisabled ? 'cursor-not-allowed text-gray-600 bg-elevation' : '';
+
+  const IconOfState = (): ReactElement => {
+    if (isLoading) {
+      return (
+        <i className="pi pi-spinner animate-spin mt-1.5 mr-1.5" data-testid={'icon-loading'} />
+      );
+    }
+    return (
+      <>
+        {isDisabled ? (
+          <i className="pi pi-ban mt-1.5 mr-1.5" data-testid={'icon-disabled'} />
+        ) : (
+          <Icon className={'mt-1.5 mr-1.5'} data-testid={testId} />
+        )}
+      </>
+    );
+  };
+
   return (
     <button
-      className={'dark:hover:bg-elevation hover:bg-gray-200 py-1 px-3 mr-1 rounded text-lg flex'}
+      disabled={isDisabled}
+      className={`${disabledClasses} dark:hover:bg-elevation hover:bg-gray-200 py-1 px-3 mr-1 rounded text-lg flex`}
       onClick={(e?) => onClick(e)}
     >
-      <Icon className={'mt-1.5 mr-1.5'} data-testid={testId} />
+      <IconOfState />
       {label}
     </button>
   );

--- a/packages/components/src/ButtonWithIcon.tsx
+++ b/packages/components/src/ButtonWithIcon.tsx
@@ -19,31 +19,23 @@ export const ButtonWithIcon = ({
   disabled,
   loading,
 }: ButtonProps): ReactElement => {
-  const isLoading = loading !== undefined ? loading : false;
-  const isDisabled = isLoading ? true : disabled !== undefined ? disabled : false;
-
-  const disabledClasses = isDisabled ? 'cursor-not-allowed text-gray-600 bg-elevation' : '';
+  const disabledClasses =
+    disabled || loading ? 'cursor-not-allowed text-gray-600 bg-elevation' : '';
 
   const IconOfState = (): ReactElement => {
-    if (isLoading) {
+    if (loading)
       return (
         <i className="pi pi-spinner animate-spin mt-1.5 mr-1.5" data-testid={'icon-loading'} />
       );
-    }
-    return (
-      <>
-        {isDisabled ? (
-          <i className="pi pi-ban mt-1.5 mr-1.5" data-testid={'icon-disabled'} />
-        ) : (
-          <Icon className={'mt-1.5 mr-1.5'} data-testid={testId} />
-        )}
-      </>
-    );
+
+    if (disabled) return <i className="pi pi-ban mt-1.5 mr-1.5" data-testid={'icon-disabled'} />;
+
+    return <Icon className={'mt-1.5 mr-1.5'} data-testid={testId} />;
   };
 
   return (
     <button
-      disabled={isDisabled}
+      disabled={disabled || loading}
       className={`${disabledClasses} dark:hover:bg-elevation hover:bg-gray-200 py-1 px-3 mr-1 rounded text-lg flex`}
       onClick={(e?) => onClick(e)}
     >

--- a/packages/playground/src/app/Header/index.tsx
+++ b/packages/playground/src/app/Header/index.tsx
@@ -40,6 +40,7 @@ export const Header = (): ReactElement => {
           onClick={() => {
             alert('Download!');
           }}
+          loading={state.compile.type === 'IN_PROGRESS'}
         />
         <ButtonWithIcon
           label="Settings"

--- a/packages/playground/src/app/Header/index.tsx
+++ b/packages/playground/src/app/Header/index.tsx
@@ -41,6 +41,7 @@ export const Header = (): ReactElement => {
           onClick={() => {
             alert('Download!');
           }}
+          disabled={!state.monacoUri}
           loading={state.compile.type === 'IN_PROGRESS'}
         />
         <ButtonWithIcon

--- a/packages/playground/src/app/Header/index.tsx
+++ b/packages/playground/src/app/Header/index.tsx
@@ -32,6 +32,7 @@ export const Header = (): ReactElement => {
           Icon={CompileIcon}
           testId={'buttonIcon'}
           onClick={() => compile(state, dispatch, dispatchMessage)}
+          disabled={!state.monacoUri}
         />
         <ButtonWithIcon
           label="Download"

--- a/packages/playground/src/app/Header/index.tsx
+++ b/packages/playground/src/app/Header/index.tsx
@@ -32,7 +32,7 @@ export const Header = (): ReactElement => {
           Icon={CompileIcon}
           testId={'buttonIcon'}
           onClick={() => compile(state, dispatch, dispatchMessage)}
-          disabled={!state.monacoUri}
+          loading={state.compile.type === 'IN_PROGRESS'}
         />
         <ButtonWithIcon
           label="Download"


### PR DESCRIPTION
This PR introduces optional disabled and loading props to the ButtonWithIcon component and displays the button state accordingly.

A button with loading state is always disabled too.

Tasks:
- [x] The `IconButton` should receive to addiational input parameters/booleans: `loading` and `disabled`.
- [x] The Icon button should reflect the Input parameters with animated spinner and disabled appearance, onClick event handler should be disabled when `diabled=true`
- [x] Add unit tests, especially for disabled feature.
- [x] The download button should display a animated Spinner when compile state is `IN_PROGRESS`.
- [x] The Download button should be disabled when monaco editor is not ready (that means `monacoUri` is not set in context state)