### PR TITLE
set correct fileId, replace hardcoded ID by constants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ docker-run:
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --publish $(DOCKER_PORT):4000 \
 	  ink-playground
-
+	  
 docker-run-detach:
 	docker run \
 	  --name ink-playground-container \

--- a/crates/rust_analyzer_wasm/src/lib.rs
+++ b/crates/rust_analyzer_wasm/src/lib.rs
@@ -66,6 +66,8 @@ extern crate web_sys;
 use rayon::prelude::*;
 pub use wasm_bindgen_rayon::init_thread_pool;
 
+const FILE_ID: u32 = 62;
+
 fn derive_analytics(host: &AnalysisHost, file_id: FileId) -> JsValue {
     let analysis = host.analysis();
     let line_index = analysis.file_line_index(file_id).unwrap();
@@ -132,7 +134,7 @@ pub struct WorldState {
 impl WorldState {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        let file_id = FileId(183);
+        let file_id = FileId(FILE_ID);
         let analysis_host = AnalysisHost::default();
         let analysis = analysis_host.analysis();
         let analysis_host = AnalysisHost::default();

--- a/packages/playground/src/app/Editor/utils/startRustAnalyzer.ts
+++ b/packages/playground/src/app/Editor/utils/startRustAnalyzer.ts
@@ -7,6 +7,7 @@ import { WorkerApi } from './wasm.worker';
 import { configureLanguage, setTokens, Token } from './configureLanguage';
 
 const modeId = 'ra-rust'; // not "rust" to circumvent conflict
+const FILE_ID = 62;
 
 export const startRustAnalyzer = async (uri: Uri) => {
   const model = monaco.editor.getModel(uri);
@@ -45,7 +46,7 @@ export const startRustAnalyzer = async (uri: Uri) => {
     if (!model) return;
     const text = model.getValue();
     await worldState.update(text);
-    const res = await worldState.analyze(183);
+    const res = await worldState.analyze(FILE_ID);
     console.log(res);
     monaco.editor.setModelMarkers(model, modeId, res.diagnostics);
     allTokens.length = 0;


### PR DESCRIPTION
Sets the FileId which is analyzed by rust analyzer to the correct value, replaces hardcoded values by constants.

remark: temporary fix, rust anlayzer should learn to read the id of the edited file automaticcally, but this requires more work....