### PR TITLE
Detect the id of the contract crate automatically

### DIFF
--- a/crates/change_json/src/change_json.rs
+++ b/crates/change_json/src/change_json.rs
@@ -19,7 +19,7 @@ use base_db::{
     FileId,
     FileSet,
     SourceRoot,
-    VfsPath,
+    VfsPath, CrateId,
 };
 use crate_graph_json::CrateGraphJson;
 use serde::{
@@ -91,6 +91,16 @@ impl From<ChangeJson> for Change {
     fn from(change_json: ChangeJson) -> Self {
         Change::from(&change_json)
     }
+}
+
+trait Find {
+    fn find_crate(&self, display_name: &str) -> Option<CrateId>;
+}
+
+impl Find for CrateGraph {
+    fn find_crate(&self, display_name: &str) -> Option<CrateId> {
+    self.iter().find(|it| self[*it].display_name.as_deref() == Some(display_name))
+}
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/crates/change_json/src/change_json.rs
+++ b/crates/change_json/src/change_json.rs
@@ -64,6 +64,22 @@ impl From<Change> for ChangeJson {
     }
 }
 
+pub trait Find {
+    fn find_crate(&self, display_name: &str) -> Option<CrateId>;
+}
+
+impl Find for CrateGraph {
+    fn find_crate(&self, display_name: &str) -> Option<CrateId> {
+    self.iter().find(|it| self[*it].display_name.as_deref() == Some(display_name))
+}
+}
+
+impl Find for Change {
+    fn find_crate(&self, display_name: &str) -> Option<CrateId> {
+        self.crate_graph.as_ref()?.find_crate(display_name)
+    }
+}
+
 impl From<&ChangeJson> for Change {
     fn from(change_json: &ChangeJson) -> Self {
         let mut change = Change::default();
@@ -92,17 +108,6 @@ impl From<ChangeJson> for Change {
         Change::from(&change_json)
     }
 }
-
-trait Find {
-    fn find_crate(&self, display_name: &str) -> Option<CrateId>;
-}
-
-impl Find for CrateGraph {
-    fn find_crate(&self, display_name: &str) -> Option<CrateId> {
-    self.iter().find(|it| self[*it].display_name.as_deref() == Some(display_name))
-}
-}
-
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 struct SourceRootJson {
     roots: Vec<Vec<(u32, Option<String>)>>,

--- a/crates/change_json/src/change_json.rs
+++ b/crates/change_json/src/change_json.rs
@@ -16,10 +16,11 @@ use crate::crate_graph_json;
 use base_db::{
     Change,
     CrateGraph,
+    CrateId,
     FileId,
     FileSet,
     SourceRoot,
-    VfsPath, CrateId,
+    VfsPath,
 };
 use crate_graph_json::CrateGraphJson;
 use serde::{
@@ -70,8 +71,9 @@ pub trait Find {
 
 impl Find for CrateGraph {
     fn find_crate(&self, display_name: &str) -> Option<CrateId> {
-    self.iter().find(|it| self[*it].display_name.as_deref() == Some(display_name))
-}
+        self.iter()
+            .find(|it| self[*it].display_name.as_deref() == Some(display_name))
+    }
 }
 
 impl Find for Change {

--- a/crates/change_json/src/lib.rs
+++ b/crates/change_json/src/lib.rs
@@ -15,4 +15,7 @@
 mod change_json;
 mod crate_graph_json;
 
-pub use crate::change_json::{ChangeJson, Find};
+pub use crate::change_json::{
+    ChangeJson,
+    Find,
+};

--- a/crates/change_json/src/lib.rs
+++ b/crates/change_json/src/lib.rs
@@ -15,4 +15,4 @@
 mod change_json;
 mod crate_graph_json;
 
-pub use crate::change_json::ChangeJson;
+pub use crate::change_json::{ChangeJson, Find};

--- a/crates/rust_analyzer_wasm/src/lib.rs
+++ b/crates/rust_analyzer_wasm/src/lib.rs
@@ -15,7 +15,10 @@
 #![cfg(target_arch = "wasm32")]
 #![allow(non_snake_case)]
 
-use change_json::{ChangeJson, Find};
+use change_json::{
+    ChangeJson,
+    Find,
+};
 use ide::{
     Analysis,
     AnalysisHost,
@@ -153,7 +156,11 @@ impl WorldState {
             serde_json::from_str(&json).expect("`Change` deserialization must work");
         let change = Change::from(change);
         if let Some(crate_id) = change.find_crate(FILE_NAME) {
-            let file_id = &change.crate_graph.as_ref().expect("Can not find CrateData for edited file")[crate_id].root_file_id;
+            let file_id = &change
+                .crate_graph
+                .as_ref()
+                .expect("Can not find CrateData for edited file")[crate_id]
+                .root_file_id;
             self.file_id = *file_id;
         };
         self.analysis_host.apply_change(change);


### PR DESCRIPTION
This PR adds:
- the `Find` trait to the `Change` in the `change_json` trait which allows to find a crate by its display name.
- automatic detection of the `CrateId` fo the `contract` crate in `rust_analyzer_wasm`
- conversion of the detected `CrateId` to its corresponding `FileId`