### PR TITLE
Add compress middleware

### DIFF
--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -32,6 +32,7 @@ use crate::{
 use actix_cors::Cors;
 use actix_web::{
     middleware::{
+        self,
         Condition,
         DefaultHeaders,
     },
@@ -64,6 +65,7 @@ async fn main() -> std::io::Result<()> {
         let frontend_folder = opts.frontend_folder.clone();
 
         let mut app = App::new()
+            .wrap(middleware::Compress::default())
             .wrap(Condition::new(opts.dev_mode, Cors::permissive()))
             .wrap(
                 DefaultHeaders::new()


### PR DESCRIPTION
This PR adds the compression middleware to the actix web server.

# Compression

## Before
![Screenshot from 2021-12-09 13-21-02](https://user-images.githubusercontent.com/18749447/145397708-d68c2234-a9d2-4d12-bb39-3d7f686f8cbf.png)

## After
![Screenshot from 2021-12-09 13-19-03](https://user-images.githubusercontent.com/18749447/145397704-b0156965-2b17-4307-911b-33d38ad74009.png)


# Chaching

## disabled
![disable](https://user-images.githubusercontent.com/18749447/145399924-c4fc5f76-9aa9-4e16-b5c9-91942b3f638e.png)

## enabled
![enable](https://user-images.githubusercontent.com/18749447/145399929-6bea77a3-25f4-4fd5-b1f0-6545cb755c51.png)

