### PR TITLE
Add ink dependencies for all crates for change.json

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -26,6 +26,9 @@ crate-type = [
 	"cdylib",
 ]
 
+[profile.release]
+overflow-checks = false
+
 [features]
 default = ["std"]
 std = [

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -15,8 +15,8 @@ ink_lang = { version = "3.0.0-rc7", default-features = false }
 ink_prelude = { version = "3.0.0-rc7", default-features = false }
 ink_eth_compatibility = { version = "3.0.0-rc7", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
-scale-info = { version = "1", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "contract"

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -7,14 +7,16 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc6", default-features = false }
-ink_metadata = { version = "3.0.0-rc6", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc6", default-features = false }
-ink_storage = { version = "3.0.0-rc6", default-features = false }
-ink_lang = { version = "3.0.0-rc6", default-features = false }
+ink_primitives = { version = "3.0.0-rc7", default-features = false }
+ink_metadata = { version = "3.0.0-rc7", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc7", default-features = false, features = ["ink-debug"] }
+ink_storage = { version = "3.0.0-rc7", default-features = false }
+ink_lang = { version = "3.0.0-rc7", default-features = false }
+ink_prelude = { version = "3.0.0-rc7", default-features = false }
+ink_eth_compatibility = { version = "3.0.0-rc7", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+scale-info = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "contract"
@@ -27,11 +29,16 @@ crate-type = [
 [features]
 default = ["std"]
 std = [
+    "ink_primitives/std",
+    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
-    "ink_primitives/std",
+    "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
+    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []
+ink-experimental-engine = ["ink_env/ink-experimental-engine"]


### PR DESCRIPTION
This adds all ink! dependencies to the Cargo.toml file of the reference contract, so that their source code is provided to Rust Analyzer by the generated change.json file.