### PR TITLE
Add compiler Dockerfile

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -15,8 +15,8 @@ ink_lang = { version = "3.0.0-rc7", default-features = false }
 ink_prelude = { version = "3.0.0-rc7", default-features = false }
 ink_eth_compatibility = { version = "3.0.0-rc7", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
-scale-info = { version = "1", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "contract"

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,0 +1,14 @@
+ARG REGISTRY_PATH=docker.io/paritytech
+
+FROM ${REGISTRY_PATH}/ink-ci-linux:production
+
+# Instantiate new Contract
+RUN cargo contract new contract
+
+# Provide Cargo.toml with all ink! dependencies
+COPY Cargo.toml /builds/contract/Cargo.toml
+
+# Prebuild ink! dependencies
+RUN cd contract && cargo contract build
+
+WORKDIR /builds/contract

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -2,6 +2,10 @@ ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/ink-ci-linux:production
 
+ENV CARGO_TARGET_DIR="/target"
+
+RUN cargo install --git https://github.com/paritytech/cargo-contract
+
 # Instantiate new Contract
 RUN cargo contract new contract
 

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -2,7 +2,7 @@
 
 This Docker image is based on: https://github.com/paritytech/scripts/blob/master/dockerfiles/ink-ci-linux/Dockerfile
 
-It is modified in a way such that it provides a prebuild ink! Smart Contract in order to minimize build time for standard ink contracts without extra dependencies.
+It is modified in a way such that it provides a pre-build ink! Smart Contract in order to minimize build time for standard ink contracts without extra dependencies.
 
 ## Usage
 

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,0 +1,17 @@
+# ink! Compiler Dockerfile
+
+This Docker image is based on: https://github.com/paritytech/scripts/blob/master/dockerfiles/ink-ci-linux/Dockerfile
+
+It is modified in a way such that it provides a prebuild ink! Smart Contract in order to minimize build time for standard ink contracts without extra dependencies.
+
+## Usage
+
+While being within the `Dockerfile` directory, build it with:
+
+`sudo docker build -t ink-backend .`
+
+Then, to compile a ink! Smart Contract file `lib.rs`, enter:
+
+`docker run --volume $local_path_to_source$:/builds/contract/lib.rs --volume $local_path_to_result$:/output ink-backend /bin/bash -c "cargo contract build && mv /target/ink/*.contract /output/"`
+
+where you should replace `$local_path_to_source$` to the path on your local machine pointing to `lib.rs` and `$local_path_to_result$` by your desired output path for the resulting `.contract` file.


### PR DESCRIPTION
This PR:

- adds the Dockerfile from which we build the Docker image for Smart Contract compilation to the repo
- the Dockerfile is simplified by extending from the existing Docker image `paritytech/ink-ci-linux:production`
- adds all ink1 dependencies to the pre-build Smart Contract, so that they are available within the Docker image for future builds from `ink-playground`, where we cap network connection for security reasons