### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/compiler_docker.yml
+++ b/.github/workflows/compiler_docker.yml
@@ -39,5 +39,8 @@ jobs:
           username: ${{ secrets.DOCKER_USER_NAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
+      - name: Tag Docker image
+        run: docker tag ink-backend:latest ${{ secrets.DOCKER_USER_NAME }}/ink-backend
+
       - name: Push Docker image
         run: docker push ${{ secrets.DOCKER_USER_NAME }}/ink-backend

--- a/.github/workflows/compiler_docker.yml
+++ b/.github/workflows/compiler_docker.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache docker images
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-docker-images
+        with:
+          path: /var/lib/docker
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
+
       - name: Compare Cargo.toml files
         run: diff ./compiler/Cargo.toml ./crates/contract/Cargo.toml
 
@@ -23,6 +31,8 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main' && github.repository == 'paritytech/ink-playground'
     steps:
+      - uses: actions/checkout@v2
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache docker images
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-docker-images
+        with:
+          path: /var/lib/docker
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
+
       - name: get Sysbox
         run: wget https://downloads.nestybox.com/sysbox/releases/v0.4.1/sysbox-ce_0.4.1-0.ubuntu-focal_amd64.deb
 
@@ -53,6 +61,14 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main' && github.repository == 'paritytech/ink-playground'
     steps:
+      - name: Cache docker images
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-docker-images
+        with:
+          path: /var/lib/docker
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.sha }}
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,8 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main' && github.repository == 'paritytech/ink-playground'
     steps:
+      - uses: actions/checkout@v2
+
       - name: Cache docker images
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
Teh last PR #196  made an update on the CI which separated the build and push processes in the workflows for the `docker` and `compiler_docker` images into two separate jobs. Unfortunately, the `push` jobs are currently not able to acceess the Docker images that the `build` jobs created.

This PR fices this by intrudocing caching of the docker image folder `/var/lib/docker` by using the GitHub action `actions/cache@v2`.