### PR TITLE
Upgrade ink 3 0

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "contrwct"
-version = "3.0.0-rc9"
+name = "contract"
+version = "3.0"
 edition = "2021"
 authors = ["Achim Schneider <achim@parity.io>"]
 license = "Apache-2.0"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "contract"
-version = "3.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Achim Schneider <achim@parity.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-ink_primitives = { version = "3.0", default-features = false }
-ink_metadata = { version = "3.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0", default-features = false }
-ink_lang = { version = "3.0", default-features = false }
-ink_prelude = { version = "3.0", default-features = false }
-ink_eth_compatibility = { version = "3.0", default-features = false }
+ink_primitives = { version = "3.0.0", default-features = false }
+ink_metadata = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0", default-features = false, features = ["ink-debug"] }
+ink_storage = { version = "3.0.0", default-features = false }
+ink_lang = { version = "3.0.0", default-features = false }
+ink_prelude = { version = "3.0.0", default-features = false }
+ink_eth_compatibility = { version = "3.0.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -20,7 +20,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 
 
 [lib]
-name = "flipper"
+name = "contract"
 path = "lib.rs"
 crate-type = [
 	# Used for normal contract Wasm blobs.

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "contract"
+name = "contrwct"
 version = "3.0.0-rc9"
 edition = "2021"
 authors = ["Achim Schneider <achim@parity.io>"]
@@ -7,20 +7,20 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc9", default-features = false }
-ink_metadata = { version = "3.0.0-rc9", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc9", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0.0-rc9", default-features = false }
-ink_lang = { version = "3.0.0-rc9", default-features = false }
-ink_prelude = { version = "3.0.0-rc9", default-features = false }
-ink_eth_compatibility = { version = "3.0.0-rc9", default-features = false }
+ink_primitives = { version = "3.0", default-features = false }
+ink_metadata = { version = "3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0", default-features = false, features = ["ink-debug"] }
+ink_storage = { version = "3.0", default-features = false }
+ink_lang = { version = "3.0", default-features = false }
+ink_prelude = { version = "3.0", default-features = false }
+ink_eth_compatibility = { version = "3.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]
-name = "contract"
+name = "flipper"
 path = "lib.rs"
 crate-type = [
 	# Used for normal contract Wasm blobs.

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -41,4 +41,3 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
-ink-experimental-engine = ["ink_env/ink-experimental-engine"]

--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -6,7 +6,7 @@ ENV CARGO_TARGET_DIR="/target"
 
 RUN cargo install dylint-link cargo-dylint
 
-RUN cargo install --git https://github.com/paritytech/cargo-contract
+RUN cargo install cargo-contract
 
 # Instantiate new Contract
 RUN cargo contract new contract

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "contrwct"
-version = "3.0.0-rc9"
+name = "contract"
+version = "3.0"
 edition = "2021"
 authors = ["Achim Schneider <achim@parity.io>"]
 license = "Apache-2.0"

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "contract"
-version = "3.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["Achim Schneider <achim@parity.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-ink_primitives = { version = "3.0", default-features = false }
-ink_metadata = { version = "3.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0", default-features = false }
-ink_lang = { version = "3.0", default-features = false }
-ink_prelude = { version = "3.0", default-features = false }
-ink_eth_compatibility = { version = "3.0", default-features = false }
+ink_primitives = { version = "3.0.0", default-features = false }
+ink_metadata = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0", default-features = false, features = ["ink-debug"] }
+ink_storage = { version = "3.0.0", default-features = false }
+ink_lang = { version = "3.0.0", default-features = false }
+ink_prelude = { version = "3.0.0", default-features = false }
+ink_eth_compatibility = { version = "3.0.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -20,7 +20,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 
 
 [lib]
-name = "flipper"
+name = "contract"
 path = "lib.rs"
 crate-type = [
 	# Used for normal contract Wasm blobs.

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "contract"
+name = "contrwct"
 version = "3.0.0-rc9"
 edition = "2021"
 authors = ["Achim Schneider <achim@parity.io>"]
@@ -7,20 +7,20 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc9", default-features = false }
-ink_metadata = { version = "3.0.0-rc9", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc9", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0.0-rc9", default-features = false }
-ink_lang = { version = "3.0.0-rc9", default-features = false }
-ink_prelude = { version = "3.0.0-rc9", default-features = false }
-ink_eth_compatibility = { version = "3.0.0-rc9", default-features = false }
+ink_primitives = { version = "3.0", default-features = false }
+ink_metadata = { version = "3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0", default-features = false, features = ["ink-debug"] }
+ink_storage = { version = "3.0", default-features = false }
+ink_lang = { version = "3.0", default-features = false }
+ink_prelude = { version = "3.0", default-features = false }
+ink_eth_compatibility = { version = "3.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]
-name = "contract"
+name = "flipper"
 path = "lib.rs"
 crate-type = [
 	# Used for normal contract Wasm blobs.

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -41,4 +41,3 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
-ink-experimental-engine = ["ink_env/ink-experimental-engine"]

--- a/crates/sandbox/src/example_code.rs
+++ b/crates/sandbox/src/example_code.rs
@@ -15,62 +15,62 @@
 #[cfg(test)]
 pub mod tests {
     pub const FLIPPER_CODE: &str = r#"
-#![cfg_attr(not(feature = "std"), no_std)]
+    #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_lang as ink;
-
-#[ink::contract]
-pub mod flipper {
-    #[ink(storage)]
-    pub struct Flipper {
-        value: bool,
+    use ink_lang as ink;
+    
+    #[ink::contract]
+    pub mod flipper {
+        #[ink(storage)]
+        pub struct Flipper {
+            value: bool,
+        }
+    
+        impl Flipper {
+            /// Creates a new flipper smart contract initialized with the given value.
+            #[ink(constructor)]
+            pub fn new(init_value: bool) -> Self {
+                Self { value: init_value }
+            }
+    
+            /// Creates a new flipper smart contract initialized to `false`.
+            #[ink(constructor)]
+            pub fn default() -> Self {
+                Self::new(Default::default())
+            }
+    
+            /// Flips the current value of the Flipper's boolean.
+            #[ink(message)]
+            pub fn flip(&mut self) {
+                self.value = !self.value;
+            }
+    
+            /// Returns the current value of the Flipper's boolean.
+            #[ink(message)]
+            pub fn get(&self) -> bool {
+                self.value
+            }
+        }
+    
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+            use ink_lang as ink;
+    
+            #[ink::test]
+            fn default_works() {
+                let flipper = Flipper::default();
+                assert!(!flipper.get());
+            }
+    
+            #[ink::test]
+            fn it_works() {
+                let mut flipper = Flipper::new(false);
+                assert!(!flipper.get());
+                flipper.flip();
+                assert!(flipper.get());
+            }
+        }
     }
-
-    impl Flipper {
-        /// Creates a new flipper smart contract initialized with the given value.
-        #[ink(constructor)]
-        pub fn new(init_value: bool) -> Self {
-            Self { value: init_value }
-        }
-
-        /// Creates a new flipper smart contract initialized to `false`.
-        #[ink(constructor)]
-        pub fn default() -> Self {
-            Self::new(Default::default())
-        }
-
-        /// Flips the current value of the Flipper's boolean.
-        #[ink(message)]
-        pub fn flip(&mut self) {
-            self.value = !self.value;
-        }
-
-        /// Returns the current value of the Flipper's boolean.
-        #[ink(message)]
-        pub fn get(&self) -> bool {
-            self.value
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use ink_lang as ink;
-
-        #[ink::test]
-        fn default_works() {
-            let flipper = Flipper::default();
-            assert!(!flipper.get());
-        }
-
-        #[ink::test]
-        fn it_works() {
-            let mut flipper = Flipper::new(false);
-            assert!(!flipper.get());
-            flipper.flip();
-            assert!(flipper.get());
-        }
-    }
-}
 "#;
 }


### PR DESCRIPTION
This PR:

- upgrades the ink! dependencies to Version 3.0 for compiler Docker image and rust analyzer
- now installs `cargo-contract` from crates.io instead of git
- removes `ink-experimental-engine`from `Cargo.toml` features