### PR TITLE
check for existing key for code in props

### DIFF
--- a/packages/ink-editor/src/index.tsx
+++ b/packages/ink-editor/src/index.tsx
@@ -144,7 +144,7 @@ export const InkEditor = (props: InkEditorProps): ReactElement | null => {
   const darkTheme = props.rustAnalyzer ? 'custom-dark' : 'default-dark';
   const lightTheme = props.rustAnalyzer ? 'custom-light' : 'vs';
 
-  if (props.code)
+  if (Object.prototype.hasOwnProperty.call(props, 'code'))
     return (
       <MonacoEditor
         language="rust"


### PR DESCRIPTION
Fiex #213 by checking for existing `code` prop in ink-editor, so it doesn't disappear on `code=''`.