### PR TITLE
downgrade containerd.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,8 @@ RUN echo \
 
 RUN apt-get --yes update
 
-RUN apt-get --yes install docker-ce docker-ce-cli containerd.io
+RUN apt-get --yes install docker-ce docker-ce-cli \
+    containerd.io=1.5.11-1
 
 # Provide startup scripts
 


### PR DESCRIPTION
Downgrades containerd.io version in Dockerfile which is used for deployment.

Should fix #217 