### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: Europe/Berlin
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,16 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: daily
-      time: "03:00"
+      time: '03:00'
       timezone: Europe/Berlin
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
   - package-ecosystem: cargo
-    directory: "/"
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
This PR adds `dependabot` to repository. To automate dependency updates and security vulnerabilities fixes.  
Related issue https://github.com/paritytech/ci_cd/issues/114