### PR TITLE
specify scope for find_all_refs

### DIFF
--- a/crates/rust_analyzer_wasm/src/lib.rs
+++ b/crates/rust_analyzer_wasm/src/lib.rs
@@ -44,6 +44,7 @@ pub use ide_db::{
         SourceRoot,
         VfsPath,
     },
+    search::SearchScope,
 };
 use ide_db::{
     imports::insert_use::{
@@ -270,13 +271,12 @@ impl WorldState {
     ) -> JsValue {
         log::warn!("references");
         let line_index = self.analysis().file_line_index(self.file_id).unwrap();
-
         let pos = file_position(line_number, column, &line_index, self.file_id);
-        let info = match self.analysis().find_all_refs(pos, None).unwrap() {
+        let search_scope = Some(SearchScope::single_file(self.file_id));
+        let info = match self.analysis().find_all_refs(pos, search_scope).unwrap() {
             Some(info) => info,
             _ => return JsValue::NULL,
         };
-
         let mut res = vec![];
         for result in info {
             if include_declaration {


### PR DESCRIPTION
  This fixes #277 , the issue was the reference provider,: it called `find_all_refs` on the analysis snapshot of RA without restricting it scope. When editing e.g. a `bool` identifier, this tried to find a occurences of `bool` in the code base.