### PR TITLE
Use array buffer

### DIFF
--- a/crates/rust_analyzer_wasm/src/lib.rs
+++ b/crates/rust_analyzer_wasm/src/lib.rs
@@ -104,9 +104,10 @@ impl WorldState {
         Self { host, file_id }
     }
 
-    pub fn load(&mut self, json: String) {
+    pub fn load(&mut self, json: Vec<u8>) {
         log::warn!("update");
         init_panic_hook();
+        let json = String::from_utf8_lossy(&json);
         web_sys::console::log_1(&"load!".into());
         let change: ChangeJson =
             serde_json::from_str(&json).expect("`Change` deserialization must work");

--- a/packages/ink-editor/src/utils/startRustAnalyzer.ts
+++ b/packages/ink-editor/src/utils/startRustAnalyzer.ts
@@ -36,10 +36,11 @@ export const startRustAnalyzer = async (uri: Uri) => {
 
   const allTokens: Array<Token> = [];
   monaco.languages.onLanguage(modeId, configureLanguage(worldState, allTokens));
-
   const data = await fetch(`./change.json`);
   const textData = await data.text();
-  await worldState.load(textData);
+  const encoder = new TextEncoder();
+  const bufferData = encoder.encode(textData);
+  await worldState.load(bufferData);
 
   async function update() {
     if (!model) return;


### PR DESCRIPTION
Currently Firefox crashes while loading Rust Analyzer WASM as reported in #310 . The crash is due to the data transfer of a huge String from the React code to the WASM WebWorker containing all the ink! projects source code and its dependency graph. 

This crashing can be prevented by passing an ArrayBuffer (`Vec<u8>`) instead of an `String` to the WASM worker thread, since modern Browser are optimized for passing ArrayBuffers between Worker threads(https://developer.chrome.com/blog/workers-arraybuffer/). 

This is done by:

- use [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) to convert the String into an ArrayBuffer in the React TypeScript code
- use [String::from_utf8_lossy](https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy) to convert the Arraybuffer(`Vec<u8>`) back to `String` on the Rust side.