### PR TITLE
use ENV variable to define analytics URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ COMPILE_URL ?= http://localhost:4000/compile
 
 TESTING_URL ?= http://localhost:4000/test
 
+ANALYTICS_URL ?= https://api-sa.substrate.io
+
 DOCKER_USER_NAME ?= achimcc
 
 ################################################################################
@@ -57,6 +59,7 @@ playground-build:
 	TESTING_URL=/test \
 	GIST_LOAD_URL=/gist/load \
 	GIST_CREATE_URL=/gist/create \
+	ANALYTICS_URL=$(ANALYTICS_URL) \
 	yarn workspace playground run build
 
 playground-start:
@@ -64,6 +67,7 @@ playground-start:
 	TESTING_URL=$(TESTING_URL) \
 	GIST_LOAD_URL=$(GIST_LOAD_URL) \
 	GIST_CREATE_URL=$(GIST_CREATE_URL) \
+	ANALYTICS_URL=$(ANALYTICS_URL) \
 	yarn workspace playground run start
 
 playground-clean:

--- a/packages/playground/src/index.html
+++ b/packages/playground/src/index.html
@@ -12,10 +12,10 @@
     <!--
       Initiate Analytics
     -->
-    <script async defer src="https://api-sa.substrate.io/latest.js"></script>
+    <script async defer src="<%= htmlWebpackPlugin.options.analyticsUrl %>/latest.js"></script>
     <noscript
       ><img
-        src="https://api-sa.substrate.io/noscript.gif"
+        src="<%= htmlWebpackPlugin.options.analyticsUrl %>/noscript.gif"
         alt=""
         referrerpolicy="no-referrer-when-downgrade"
     /></noscript>

--- a/packages/playground/webpack.config.js
+++ b/packages/playground/webpack.config.js
@@ -9,6 +9,7 @@ const { merge } = require('webpack-merge');
 const inkEditorConfig = require('../ink-editor/webpack.config');
 const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
+const analyticsUrl = process.env.ANALYTICS_URL;
 
 const localConfig = {
   mode: 'development',
@@ -54,6 +55,7 @@ const localConfig = {
       title: 'Parity ink! Playground',
       favicon: './public/favicon.ico',
       template: './src/index.html',
+      analyticsUrl: `${analyticsUrl}`,
     }),
     new CopyPlugin({
       patterns: [{ from: './public/favicon.ico' }, { from: './public/favicon.png' }],


### PR DESCRIPTION
- fixes the broken analytics URL which was reported in: https://github.com/paritytech/web/issues/4
- defines the Analytics Backend URL through a .env variable