### PR TITLE
diable unresolved-macro-call errors

### DIFF
--- a/crates/rust_analyzer_wasm/src/lib.rs
+++ b/crates/rust_analyzer_wasm/src/lib.rs
@@ -479,7 +479,8 @@ impl WorldState {
     fn derive_analytics(&self) -> JsValue {
         let analysis = self.analysis();
         let line_index = analysis.file_line_index(self.file_id).unwrap();
-        let config = DiagnosticsConfig::default();
+        let mut config = DiagnosticsConfig::default();
+        config.disabled.insert("unresolved-macro-call".to_string());
         let diagnostics: Vec<_> = analysis
             .diagnostics(&config, AssistResolveStrategy::None, self.file_id)
             .unwrap()


### PR DESCRIPTION
Fixes the unresolved-macro error currently showing up on staging by disabling `unresolved-macro-call` in diagnostics settings of Rust Analyzer.