### PR TITLE
update sysbox binary url

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: get Sysbox
-        run: wget https://downloads.nestybox.com/sysbox/releases/v0.5.0/sysbox-ce_0.5.0-0.linux_amd64.deb
+        run: wget https://downloads.nestybox.com/sysbox/releases/v0.5.2/sysbox-ce_0.5.2-0.linux_amd64.deb 
 
       - name: Install Sysbox
-        run: sudo apt-get install ./sysbox-ce_0.5.0-0.linux_amd64.deb
+        run: sudo apt-get install ./sysbox-ce_0.5.2-0.linux_amd64.deb
 
       - name: Configure Sysbox runtime
         run: sudo cp sysbox/daemon.json /etc/docker/daemon.json

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: get Sysbox
-        run: wget https://downloads.nestybox.com/sysbox/releases/v0.5.2/sysbox-ce_0.5.2-0.linux_amd64.deb 
+        run: wget https://downloads.nestybox.com/sysbox/releases/v0.5.2/sysbox-ce_0.5.2-0.linux_amd64.deb
 
       - name: Install Sysbox
         run: sudo apt-get install ./sysbox-ce_0.5.2-0.linux_amd64.deb


### PR DESCRIPTION
Upddates the outdated link in GitHub CI for the sysbox binary to https://downloads.nestybox.com/sysbox/releases/v0.5.2/sysbox-ce_0.5.2-0.linux_amd64.deb